### PR TITLE
Specification

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -17,7 +17,14 @@
     "type": {
       "type": "object",
       "propertyNames": {
-        "pattern": "^(efa|hafasMgate|hafasQuery|navitia|otpGraphQl|otpRest)$"
+        "enum": [
+          "efa",
+          "hafasMgate",
+          "hafasQuery",
+          "navitia",
+          "otpGraphQl",
+          "otpRest"
+        ]
       },
       "additionalProperties": {
         "type": "boolean"

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,65 @@
+{
+  "$id": "https://raw.githubusercontent.com/public-transport/transport-apis/v1/schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "public transport API description",
+  "type": "object",
+  "required": [
+    "name",
+    "type",
+    "supportedLanguages",
+    "coverage",
+    "options"
+  ],
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "type": {
+      "type": "object",
+      "propertyNames": {
+        "pattern": "^(efa|hafasMgate|hafasQuery|navitia|otpGraphQl|otpRest)$"
+      },
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "supportedLanguages": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z][a-z]$",
+        "description": "ISO-639-1 language code"
+      }
+    },
+    "coverage": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": false,
+      "properties": {
+        "realtimeCoverage": {
+          "$ref": "#coverage"
+        },
+        "regularCoverage": {
+          "$ref": "#coverage"
+        },
+        "anyCoverage": {
+          "$ref": "#coverage"
+        }
+      }
+    },
+    "options": {
+      "type": "object"
+    }
+  },
+  "definitions": {
+    "coverage": {
+      "$id": "#coverage",
+      "type": "object",
+      "properties": {
+        "area": {
+      "type": "object"
+        }
+      }
+    }
+  }
+}

--- a/schema.json
+++ b/schema.json
@@ -44,13 +44,13 @@
       "additionalProperties": false,
       "properties": {
         "realtimeCoverage": {
-          "$ref": "#coverage"
+          "$ref": "#/definitions/coverage"
         },
         "regularCoverage": {
-          "$ref": "#coverage"
+          "$ref": "#/definitions/coverage"
         },
         "anyCoverage": {
-          "$ref": "#coverage"
+          "$ref": "#/definitions/coverage"
         }
       }
     },
@@ -60,7 +60,7 @@
   },
   "definitions": {
     "coverage": {
-      "$id": "#coverage",
+      "$id": "#/definitions/coverage",
       "type": "object",
       "required": [
         "type",

--- a/schema.json
+++ b/schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/public-transport/transport-apis/v1/schema.json",
+  "$id": "https://raw.githubusercontent.com/public-transport/transport-apis/v1/schema.json#",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "public transport API description",
   "type": "object",
@@ -55,9 +55,37 @@
     "coverage": {
       "$id": "#coverage",
       "type": "object",
+      "required": [
+        "type",
+        "coordinates"
+      ],
       "properties": {
-        "area": {
-      "type": "object"
+        "type": {
+          "type": "string",
+          "enum": [
+            "Polygon"
+          ]
+        },
+        "coordinates": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "minItems": 4,
+            "items": {
+              "type": "array",
+              "minItems": 2,
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "items": {
+            "type": "number"
+          }
         }
       }
     }


### PR DESCRIPTION
Add a jsonschema draft-07 compatible specification of the transport API schema. I deliberately left out the API-specific settings below the "options" block.

Apart from missing coverage information, our current data validates against the spec. Once we fix that, we can use https://github.com/marketplace/actions/validate-json to automatically validate all endpoint definitions, which should come in handy for pull requests. Note that validate-json requires an explicit list of files to validate, it does not yet support wildcard expansion or directories.