### PR TITLE
Add attribution property to schema spec

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,9 +91,13 @@ Both fields should be provided.
 
 ### Attribution Information
 
-If an endpoint provides results under an Open Data license, it should contain an
-`attribution` property which describes the license and copyright information.
-This generally follows the [Data Packages format](https://dataprotocols.org/data-packages/).
+The `attribution` property specifies licensing information for an endpoint.
+
+#### Open Data
+
+If an endpoint provides results under an Open Data license, `attribution`
+generally follows the [Data Packages
+format](https://dataprotocols.org/data-packages/):
 
 ```js
 {
@@ -108,6 +112,21 @@ This generally follows the [Data Packages format](https://dataprotocols.org/data
 Properties:
 * `license`: An [Open Definition license ID](https://licenses.opendefinition.org/) or an [SPDX license id](https://spdx.org/licenses/).
 * `name` and `homepage`: The entity to attribute for licenses requiring this.
+
+name and license are mandatory, homepage is optional.
+
+#### Proprietary
+
+If an endpoint is known to be proprietary, `attribution` can be used to specify
+this as well:
+
+```js
+{
+    "attribution": {
+        "isProprietary": true
+    }
+}
+```
 
 ### Protocol Specific Options
 

--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,9 @@ Both fields should be provided.
 
 ### Attribution Information
 
-License and copyright attribution data for endpoints providing results under an Open Data license. This generally follows the [Data Packages format](https://dataprotocols.org/data-packages/).
+If an endpoint provides result under an Open Data license, it should contain an
+`attribution` property which describes the license and copyright information.
+This generally follows the [Data Packages format](https://dataprotocols.org/data-packages/).
 
 ```js
 {
@@ -104,7 +106,7 @@ License and copyright attribution data for endpoints providing results under an 
 ```
 
 Properties:
-* `license`: An [Open Definition license ID](https://licenses.opendefinition.org/) or a [SPDX license id](https://spdx.org/licenses/).
+* `license`: An [Open Definition license ID](https://licenses.opendefinition.org/) or an [SPDX license id](https://spdx.org/licenses/).
 * `name` and `homepage`: The entity to attribute for licenses requiring this.
 
 ### Protocol Specific Options

--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ Both fields should be provided.
 
 ### Attribution Information
 
-If an endpoint provides result under an Open Data license, it should contain an
+If an endpoint provides results under an Open Data license, it should contain an
 `attribution` property which describes the license and copyright information.
 This generally follows the [Data Packages format](https://dataprotocols.org/data-packages/).
 

--- a/schema.json
+++ b/schema.json
@@ -56,22 +56,10 @@
     },
     "attribution": {
       "type": "object",
-      "required": [
-        "license",
-        "name"
-      ],
-      "properties": {
-        "license": {
-          "type": "string",
-          "description": "Open Definition license ID or SPDX license id"
-        },
-        "name": {
-          "type": "string"
-        },
-        "homepage": {
-          "type": "string"
-        }
-      }
+      "oneOf": [
+        { "$ref": "#/definitions/attribution_opendata" },
+        { "$ref": "#/definitions/attribution_proprietary" }
+      ]
     },
     "options": {
       "type": "object"
@@ -112,6 +100,36 @@
           "items": {
             "type": "number"
           }
+        }
+      }
+    },
+    "attribution_opendata": {
+      "type": "object",
+      "required": [
+        "license",
+        "name"
+      ],
+      "properties": {
+        "license": {
+          "type": "string",
+          "description": "Open Definition license ID or SPDX license id"
+        },
+        "name": {
+          "type": "string"
+        },
+        "homepage": {
+          "type": "string"
+        }
+      }
+    },
+    "attribution_proprietary": {
+      "type": "object",
+      "required": [
+        "isProprietary"
+      ],
+      "properties": {
+        "isProprietary": {
+          "type": "boolean"
         }
       }
     }

--- a/schema.json
+++ b/schema.json
@@ -54,6 +54,25 @@
         }
       }
     },
+    "attribution": {
+      "type": "object",
+      "required": [
+        "license",
+        "name"
+      ],
+      "properties": {
+        "license": {
+          "type": "string",
+          "description": "Open Definition license ID or SPDX license id"
+        },
+        "name": {
+          "type": "string"
+        },
+        "homepage": {
+          "type": "string"
+        }
+      }
+    },
     "options": {
       "type": "object"
     }


### PR DESCRIPTION
I added attribution as an optional property, as it's unknown for some endpoints. When providing attribution data, IMHO both license and name should be mandatory – even for CC0 it's common to note who is waiving their rights. The homepage doesn't seem as important to me, so I made it optional

@vkrause could you check whether this is in line with your intentions? If it is, please merge.