### PR TITLE
Validate endpoint definitions against JSON schema on each push and PR

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,20 @@
+name: Validate endpoint definitions
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  verify-json-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Validate JSON
+        uses: docker://nhalstead00/validate-json-action:latest
+        env:
+          INPUT_SCHEMA: schema.json
+          INPUT_JSONS: data/*/*.json


### PR DESCRIPTION
Turns out: There's a fork of validate-json-action with globbing support. This PR valiates all JSON definitions (`data/*/*.json`) against `schema.json` for each push and for each pull request.