### PR TITLE
Proposal: Hafas product metadata

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -187,7 +187,7 @@ The following properties are defined:
 
 Product metadata consists of the following information:
 * `id`: An URL-safe slug-ified version of the name, for machine use.
-* `name`: A humand readable label for the product, as used by the operator.
+* `name`: A human-readable label for the product, as used by the operator.
 * `bitmasks`: An array of integer values of bit values used by Hafas for this product.
 
 ## Contributing

--- a/readme.md
+++ b/readme.md
@@ -159,7 +159,20 @@ this as well:
     },
     "ext": "...",
     "micMacSalt": "<hex value>",
-    "version": "1.27"
+    "version": "1.27",
+    "products": [
+        {
+            id: 'subway',
+            name: 'U-Bahn'
+            bitmasks: [1]
+        },
+        {
+            id: 'suburban',
+            bitmasks: [2],
+            name: 'S-Bahn'
+        },
+        ...
+    ]
 }
 ```
 
@@ -170,6 +183,12 @@ The following properties are defined:
 * `ext`: String with the extension version (?) included in Hafas request.
 * `micMacSalt`: A string containing a hexadecimal representation the salt to hash the hashed request body with. Mandatory for endpoints using this authentication mechanism.
 * `version`: String containing the requested Hafas API version (?), mandatory for all known endpoints.
+* `products`: Information about the Hafas product bitmask values and the corresponding product metadata (see below).
+
+Product metadata consists of the following information:
+* `id`: An URL-safe slug-ified version of the name, for machine use.
+* `name`: A humand readable label for the product, as used by the operator.
+* `bitmasks`: An array of integer values of bit values used by Hafas for this product.
 
 ## Contributing
 


### PR DESCRIPTION
The current (undocumented) `lineModeMap` data doesn't really seem to serve neither hafas-client nor KPublicTransport very well, so here's an alternative proposal, largely inspired by what hafas-client is using right now.

* hafas-client has additional fields (`short`, `id`, `default`), the only reason I haven't added those yet is that I'm not entirely sure about the requirements/semantics for those.
* Trying to map products to transport maps is difficult, but both clients seem to do that in some form anyway, so it would seem useful to share that work as well. The most comprehensive model I am aware for this is HVT (https://developers.google.com/transit/gtfs/reference/extended-route-types), that hopefully can cover everything, and should be reasonably straightforward for everyone to map to their respective mode categories.

What do you think?