### PR TITLE
Add OTP/Digitransit endpoints in Finland and Germany

### DIFF
--- a/data/de/stadtnavi-otp.json
+++ b/data/de/stadtnavi-otp.json
@@ -1,0 +1,30 @@
+{
+    "name": "Stadtnavi",
+    "attribution": {
+        "name": "Stadtnavi",
+        "homepage": "https://stadtnavi.de/",
+        "mixedLicenses": true
+    },
+    "coverage": {
+        "realtimeCoverage": {
+            "area": {
+                "coordinates": [
+                    [
+                        [ 7.503590600000001, 49.8348605 ], [ 11.082291, 49.8348605 ], [ 11.082291, 47.525812300000005 ], [ 7.503590600000001, 47.525812300000005 ], [ 7.503590600000001, 49.8348605 ]
+                    ]
+                ],
+                "type": "Polygon"
+            },
+            "region": [ "DE-BW" ]
+        }
+    },
+    "options": {
+        "endpoint": "https://api.stadtnavi.de/routing/v1/router/",
+        "supportedTransitModes": [ "TRANSIT", "CARPOOL" ]
+    },
+    "supportedLanguages": [ "de" ],
+    "timezone": "Europe/Berlin",
+    "type": {
+        "otpGraphQl": true
+    }
+}

--- a/data/de/ulm-otp.json
+++ b/data/de/ulm-otp.json
@@ -1,0 +1,30 @@
+{
+    "name": "Verschwörhaus Ulm",
+    "attribution": {
+        "name": "Verschwörhaus",
+        "homepage": "https://digitransit.im.verschwoerhaus.de/tietoja-palvelusta",
+        "mixedLicenses": true
+    },
+    "coverage": {
+        "realtimeCoverage": {
+            "area": {
+                "coordinates": [
+                    [
+                        [ 8.6407794, 49.0365089 ], [ 11.3182223, 49.0365089 ], [ 11.3182223, 48.2892591 ], [ 8.6407794, 48.2892591 ], [ 8.6407794, 49.0365089 ]
+                    ]
+                ],
+                "type": "Polygon"
+            },
+            "region": [ "DE-BW" ]
+        }
+    },
+    "options": {
+        "endpoint": "https://api.digitransit.im.verschwoerhaus.de/routing/v1/routers/vsh/",
+        "supportedTransitModes": [ "TRANSIT", "CARPOOL" ]
+    },
+    "supportedLanguages": [ "de" ],
+    "timezone": "Europe/Berlin",
+    "type": {
+        "otpGraphQl": true
+    }
+}

--- a/data/fi/digitransit-otp.json
+++ b/data/fi/digitransit-otp.json
@@ -1,0 +1,25 @@
+{
+    "name": "Digitransit Finland",
+    "coverage": {
+        "realtimeCoverage": {
+            "area": {
+                "coordinates": [
+                    [
+                        [ 19.3167101, 70.1383835 ], [ 37.653402, 70.1383835 ], [ 37.653402, 55.776771 ], [ 19.3167101, 55.776771 ], [ 19.3167101, 70.1383835 ]
+                    ]
+                ],
+                "type": "Polygon"
+            },
+            "region": [ "FI" ]
+        }
+    },
+    "options": {
+        "endpoint": "https://api.digitransit.fi/routing/v1/routers/finland/",
+        "supportedTransitModes": [ "TRANSIT" ]
+    },
+    "supportedLanguages": [ "de", "en", "fi", "fr", "sv" ],
+    "timezone": "Europe/Helsinki",
+    "type": {
+        "otpGraphQl": true
+    }
+}

--- a/data/fi/helsinki-otp.json
+++ b/data/fi/helsinki-otp.json
@@ -1,0 +1,29 @@
+{
+    "name": "Helsinki",
+    "attribution": {
+        "license": "CC-BY-4.0",
+        "name": "© Helsinki Region Transport"
+    },
+    "coverage": {
+        "realtimeCoverage": {
+            "area": {
+                "coordinates": [
+                    [
+                        [ 19.5364379883, 66.5802673946 ], [ 29.5712215851, 66.5802673946 ], [ 29.5712215851, 59.7865148075 ], [ 19.5364379883, 59.7865148075 ], [ 19.5364379883, 66.5802673946 ]
+                    ]
+                ],
+                "type": "Polygon"
+            },
+            "region": [ "FI-17" ]
+        }
+    },
+    "options": {
+        "endpoint": "https://api.digitransit.fi/routing/v1/routers/hsl/",
+        "supportedTransitModes": [ "TRANSIT" ]
+    },
+    "supportedLanguages": [ "de", "en", "fi", "fr", "sv" ],
+    "timezone": "Europe/Helsinki",
+    "type": {
+        "otpGraphQl": true
+    }
+}

--- a/data/fi/waltti-otp.json
+++ b/data/fi/waltti-otp.json
@@ -1,0 +1,25 @@
+{
+    "name": "Waltti",
+    "coverage": {
+        "realtimeCoverage": {
+            "area": {
+                "coordinates": [
+                    [
+                        [ 19.3167101, 70.1383835 ], [ 31.5841445, 70.1383835 ], [ 31.5841445, 59.723203000000005 ], [ 19.3167101, 59.723203000000005 ], [ 19.3167101, 70.1383835 ]
+                    ]
+                ],
+                "type": "Polygon"
+            },
+            "region": [ "FI" ]
+        }
+    },
+    "options": {
+        "endpoint": "https://api.digitransit.fi/routing/v1/routers/waltti/",
+        "supportedTransitModes": [ "TRANSIT" ]
+    },
+    "supportedLanguages": [ "de", "en", "fi", "fr", "sv" ],
+    "timezone": "Europe/Helsinki",
+    "type": {
+        "otpGraphQl": true
+    }
+}


### PR DESCRIPTION
Coverage areas are the bounding boxes those endpoints report themselves.