### PR TITLE
add Steirischer Verkehrsverbund (STV)

### DIFF
--- a/data/at/stv-hafas-mgate.json
+++ b/data/at/stv-hafas-mgate.json
@@ -1,0 +1,88 @@
+{
+  "name": "Steirischer Verkehrsverbund (Verbundlinie)",
+  "type": {
+    "hafasMgate": true
+  },
+  "supportedLanguages": [
+    "de",
+    "en"
+  ],
+  "timezone": "Europe/Vienna",
+  "attribution": {
+    "name": "Verkehrsverbund Steiermark GmbH",
+    "homepage": "https://verbundlinie.at/",
+    "isProprietary": true
+  },
+  "coverage": {
+    "realtimeCoverage": {
+      "region": ["AT-6"]
+    }
+  },
+  "options": {
+    "auth": {
+      "type": "AID",
+      "aid": "wf7mcf9bv3nv8g5f"
+    },
+    "client": {
+      "id": "VAO",
+      "type": "WEB",
+      "name": "webapp",
+      "l": "vs_stv"
+    },
+    "endpoint": "https://verkehrsauskunft.verbundlinie.at/bin/mgate.exe",
+    "ext": "VAO.13",
+    "products": [
+      {
+        "id": "trains",
+        "bitmasks": [1, 2],
+        "name": "Bahn & S-Bahn"
+      },
+      {
+        "id": "regional-bus",
+        "bitmasks": [64],
+        "name": "Regionalbus"
+      },
+      {
+        "id": "city-bus",
+        "bitmasks": [128],
+        "name": "Stadtbus"
+      },
+      {
+        "id": "tram",
+        "bitmasks": [16],
+        "name": "Straßenbahn"
+      },
+      {
+        "id": "long-distance-bus",
+        "bitmasks": [32],
+        "name": "Fernbus"
+      },
+      {
+        "id": "other",
+        "bitmasks": [2048],
+        "name": "Sonstige"
+      },
+      {
+        "id": "on-call",
+        "bitmasks": [1024],
+        "name": "Anrufbus"
+      },
+      {
+        "id": "subway",
+        "bitmasks": [4],
+        "name": "U-Bahn"
+      },
+      {
+        "id": "aerial-lift",
+        "bitmasks": [256],
+        "name": "Seil-/Zahnradbahn"
+      },
+      {
+        "id": "ferry",
+        "bitmasks": [512],
+        "name": "Schiff"
+      }
+    ],
+    "ver": "1.32"
+  }
+}


### PR DESCRIPTION
Apparently they switched from EFA to HAFAS (https://github.com/alexander-albers/tripkit/issues/22).

[Their webapp](https://verkehrsauskunft.verbundlinie.at/webapp/index.html) has buttons for the languages `de`, `en`, `it` ,`hr`, `si` & `hu`; But the endpoint only has translations for `de` & `en`. Which languages shall I add to `supportedLanguages`?