### PR TITLE
add more HAFAS mgate.exe endpoints

### DIFF
--- a/data/de/db-regio-hafas-mgate.json
+++ b/data/de/db-regio-hafas-mgate.json
@@ -1,0 +1,89 @@
+{
+  "name": "Deutsche Bahn (DB)",
+  "type": {
+    "hafasMgate": true
+  },
+  "supportedLanguages": [
+    "de",
+    "en"
+  ],
+  "timezone": "Europe/Berlin",
+  "attribution": {
+    "name": "Deutsche Bahn AG",
+    "homepage": "https://bahn.de/",
+    "isProprietary": true
+  },
+  "coverage": {
+    "realtimeCoverage": {
+      "region": ["DE"]
+    },
+    "anyCoverage": {
+      "region": ["PL", "CZ", "SK", "HU", "SI", "RO", "BE", "UA", "HR", "BG", "IT", "FR", "ES", "PT", "GB", "DK", "SE"]
+    }
+  },
+  "options": {
+    "auth": {
+      "type": "AID",
+      "aid": "Xd91BNAVkuI6rr6z"
+    },
+    "checksumSalt": "7a374446424e41563048766836715137",
+    "client": {
+      "id": "DB-REGIO-BNAV",
+      "name": "StreckenagentPROD-APPSTORE",
+      "type": "IPH",
+      "v": "3000500"
+    },
+    "endpoint": "https://bnav.hafas.de/bin/mgate.exe",
+    "ext": "DB.R19.12.a",
+    "version": "1.18",
+    "products": [
+      {
+        "id": "ice",
+        "bitmasks": [1],
+        "name": "ICE"
+      },
+      {
+        "id": "ic-ec",
+        "bitmasks": [2],
+        "name": "IC/EC"
+      },
+      {
+        "id": "d-zug",
+        "bitmasks": [4],
+        "name": "D-Zug"
+      },
+      {
+        "id": "RE/RB",
+        "bitmasks": [8],
+        "name": "RE/RB"
+      },
+      {
+        "id": "s-bahn",
+        "bitmasks": [16],
+        "name": "S-Bahn"
+      },
+      {
+        "id": "bus",
+        "bitmasks": [32],
+        "name": "Bus"
+      },
+      {
+        "id": "faehre",
+        "bitmasks": [64],
+        "name": "Fähre"
+      },
+      {
+        "id": "u-bahn",
+        "bitmasks": [128],
+        "name": "U-Bahn"
+      },
+      {
+        "id": "strassenbahn",
+        "bitmasks": [256],
+        "name": "Straßenbahn"
+      }
+    ],
+    "locationIdentifierType": "db",
+    "standardLocationIdentifierType": "ibnr"
+  }
+}

--- a/data/de/db-smartrbl-hafas-mgate.json
+++ b/data/de/db-smartrbl-hafas-mgate.json
@@ -1,0 +1,64 @@
+{
+  "name": "Deutsche Bahn (DB)",
+  "type": {
+    "hafasMgate": true
+  },
+  "supportedLanguages": [
+    "de",
+    "en"
+  ],
+  "timezone": "Europe/Berlin",
+  "attribution": {
+    "name": "Deutsche Bahn AG",
+    "homepage": "https://bahn.de/",
+    "isProprietary": true
+  },
+  "coverage": {
+    "realtimeCoverage": {
+      "region": ["DE"]
+    }
+  },
+  "options": {
+    "auth": {
+      "type": "AID",
+      "aid": "izfpmpj8tnh6acye"
+    },
+    "client": {
+      "id": "HAFAS",
+      "name": "Test-Client",
+      "type": "WEB",
+      "v": "1.0.0"
+    },
+    "endpoint": "https://db-smartrbl.hafas.de/mct/mgate",
+    "version": "1.18",
+    "products": [
+      {
+        "id": "ice",
+        "bitmasks": [1],
+        "name": "ICE"
+      },
+      {
+        "id": "ic-ec",
+        "bitmasks": [2],
+        "name": "IC/EC"
+      },
+      {
+        "id": "d-zug",
+        "bitmasks": [4],
+        "name": "D-Zug"
+      },
+      {
+        "id": "RE/RB",
+        "bitmasks": [8],
+        "name": "RE/RB"
+      },
+      {
+        "id": "s-bahn",
+        "bitmasks": [16],
+        "name": "S-Bahn"
+      }
+    ],
+    "locationIdentifierType": "db",
+    "standardLocationIdentifierType": "ibnr"
+  }
+}

--- a/data/us/dart-hafas-mgate.json
+++ b/data/us/dart-hafas-mgate.json
@@ -1,0 +1,41 @@
+{
+  "name": "Dallas Area Rapid Transit (DART)",
+  "type": {
+    "hafasMgate": true
+  },
+  "supportedLanguages": [
+    "en"
+  ],
+  "timezone": "Europe/Berlin",
+  "attribution": {
+    "name": "Dallas Area Rapid Transit",
+    "homepage": "https://www.dart.org/",
+    "isProprietary": true
+  },
+  "coverage": {
+    "realtimeCoverage": {
+      "area": {"type":"Polygon","coordinates":[[[-97.22351074218749,33.56199537293026],[-97.6300048828125,33.500178528242294],[-97.9376220703125,33.19732768648872],[-97.95684814453124,32.76880048488168],[-97.88818359375,32.35676318267811],[-97.3004150390625,32.222095840502334],[-96.470947265625,32.14771106595571],[-96.07269287109375,32.312670050625805],[-95.96282958984375,32.74339241542703],[-96.053466796875,33.19732768648872],[-96.46820068359374,33.55512901742288],[-97.22351074218749,33.56199537293026]]]}
+    }
+  },
+  "options": {
+    "auth": {
+      "type": "AID",
+      "aid": "XNFGL2aSkxfDeK8N4waOZnsdJ"
+    },
+    "client": {
+      "id": "DART",
+      "type": "WEB",
+      "name": "webapp",
+      "l": "vs_webapp"
+    },
+    "endpoint": "https://auskunft.avv.de/bin/mgate.exe",
+    "ver": "1.35",
+    "products": [
+      {
+        "id": "bus",
+        "bitmasks": [32],
+        "name": "Bus"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
I have searched a public database of DNS records, and these are all (non-broken, useful) endpoints that are not included within this project yet, so once it is merged, we should have all covered.