### PR TITLE
Add support for TRIAS Endpoints

### DIFF
--- a/docs/TRIAS-Providers.md
+++ b/docs/TRIAS-Providers.md
@@ -1,0 +1,7 @@
+# List of TRIAS Providers
+
+This is a list of public transport providers that provide a TRIAS API.
+Be aware that most of them **do not offer open APIs**, but require you to sign up with them.
+To sign up the collected Links are provided.
+
+- [Verkehrsverbund Stuttgart (VVS)](https://www.openvvs.de/pages/api)

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ Known protocols:
 * `navitia`
 * `otpGraphQl`
 * `otpRest`
+* `trias`
 
 ### Supported Languages
 
@@ -109,8 +110,7 @@ The `attribution` property specifies licensing information for an endpoint.
 #### Open Data
 
 If an endpoint provides results under an Open Data license, `attribution`
-generally follows the [Data Packages
-format](https://dataprotocols.org/data-packages/):
+generally follows the [Data Packages format](https://dataprotocols.org/data-packages/):
 
 ```js
 {
@@ -268,6 +268,19 @@ The following properties are defined:
 The following properties are defined:
 * `endpoint`: Base URL for the API, without e.g. the `index/graphql` suffix.
 * `apiVersion`: One of `otp1`, `otp2` or `entur`.
+
+#### TRIAS
+
+The following properties are defined:
+* `endpoint`: Base URL for the API
+* `isTestingEndpoint`: Whether the endpoint is explictly meant for testing puposes
+* `triasVersion`: Highest [TRIAS version](https://github.com/VDVde/TRIAS/releases) supported by the API
+* `requestContentType`: [Content-Type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) e.g. `text/xml`
+* `requiresSignUp`: Whether one needs to sign up to obtain an API key.
+* `requiresContract` Whether one needs to sign a contract to use the API.
+* `authorizationMethod`: One of `Authorization-Header`, `RequestorRef`
+* `providedServices`: array of supported services as listed [in the EKAP documentation](https://www.vdv.de/431-2sdes-v-1-3.pdfx#page=51)
+* `requestLimitPolicy`: request-policy in the [markup of the `RateLimit` HTTP header](https://www.ietf.org/archive/id/draft-ietf-httpapi-ratelimit-headers-04.html#name-expressing-rate-limit-polic)
 
 ## Contributing
 

--- a/schema.json
+++ b/schema.json
@@ -23,7 +23,8 @@
           "hafasQuery",
           "navitia",
           "otpGraphQl",
-          "otpRest"
+          "otpRest",
+          "trias"
         ]
       },
       "additionalProperties": {


### PR DESCRIPTION
This Pull Request introduces a draft for the required properties for trias clients and how to specify them. The information was collected from the existing list available in [trias-client](https://github.com/andaryjo/trias-client/blob/main/docs/PROVIDERS.md). I already found some issues, I would like to discuss:

- Some Endpoints offer test-endpoints, which are usually the same as the production endpoint but at least in one case they also [differ](https://github.com/andaryjo/trias-client/blob/main/docs/PROVIDERS.md) in Authorization (see the SBB). So what I iagined would be to use a boolean that indicate, whether this is a productive or test endpoint instead of offering the test-URL. This would lead to a lot of endpoints be defined two times, with only a different URL, but would allow to specify test-endpoints as that differ in more then the base URL.
- I wasn't sure how to define access: In the mentioned documentation sometimes a contract is required, but independent from whether a registration is required or not. Currently this is implicitly defined, if you need an authorization you usually need an registration as well. Except for the SBB testpoint, where you need an authorization with an publicly available key.
- A link to the documentation of the endpoint (and for registration) would be useful for developers. However this repo states to be "machine-readable" and in the other definitions, it is also not available. So should we add it or not?

Every kind of feedback is appreciated.