### PR TITLE
DE: add bwegt TRIAS

### DIFF
--- a/data/de/bwegt-trias.json
+++ b/data/de/bwegt-trias.json
@@ -1,0 +1,29 @@
+{
+    "name": "bwegt",
+    "coverage": {
+        "realtimeCoverage": {
+            "area": {
+                "coordinates": [
+                    [ [ 8.3124, 49.6365 ], [ 7.2366, 47.4941 ], [ 10.473, 47.5443 ], [ 10.5414, 49.9647 ], [ 8.3124, 49.6365 ] ]
+                ],
+                "type": "Polygon"
+            },
+            "region": [ "DE-BW" ]
+        }
+    },
+    "options": {
+        "endpoint": "http://efa-bw.de/trias",
+        "isTestingEndpoint": false,
+        "triasVersion": 1.1,
+        "requestContentType": "text/xml",
+        "requiresSignUp": true,
+        "requiresContract": false,
+        "authorizationMethod": "RequestorRef",
+        "providedServices": ["TripRequest", "StopEventRequest"]
+    },
+    "supportedLanguages": [ "en", "de" ],
+    "timezone": "Europe/Berlin",
+    "type": {
+        "trias": true
+    }
+}

--- a/docs/TRIAS-Providers.md
+++ b/docs/TRIAS-Providers.md
@@ -4,4 +4,4 @@ This is a list of public transport providers that provide a TRIAS API.
 Be aware that most of them **do not offer open APIs**, but require you to sign up with them.
 To sign up the collected Links are provided.
 
-- [Verkehrsverbund Stuttgart (VVS)](https://www.openvvs.de/pages/api)
+- [bwegt](https://www.mobidata-bw.de/dataset/trias)


### PR DESCRIPTION
This adds the bwegt/nvbw trias endpoint configuration and add a link to the website, where one can sign up for an API-Key