### PR TITLE
Add MOTIS to schema.json

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -24,7 +24,8 @@
           "navitia",
           "otpGraphQl",
           "otpRest",
-          "trias"
+          "trias",
+          "motis"
         ]
       },
       "additionalProperties": {


### PR DESCRIPTION
Missed that in my previous PR, sorry for that, but I guess this should be added prevent the schema verification from failing, when a MOTIS configuration will be added