### PR TITLE
TPG endpoints change

### DIFF
--- a/data/ch/tpg-hafas-mgate.json
+++ b/data/ch/tpg-hafas-mgate.json
@@ -29,7 +29,7 @@
       "name": "webapp",
       "l": "vs_webapp"
     },
-    "endpoint": "https://tpg-webapp.hafas.de/bin/mgate.exe",
+    "endpoint": "https://tpg.hafas.cloud/bin/mgate.exe",
     "products": [
       {
         "id": "tgv",


### PR DESCRIPTION
The TPG endpoints changed.
The one used before is still up but return errors that you cannot ask after decembre 22. The new one is the one used by TPG public website.