### PR TITLE
Apply PEP8 rules to tool scripts where feasible

### DIFF
--- a/tools/coverage-to-geojson.py
+++ b/tools/coverage-to-geojson.py
@@ -11,7 +11,8 @@ import json
 import os
 import re
 
-parser = argparse.ArgumentParser(description='Generates a GeoJSON document from coverage areas of the Transport API Repository')
+parser = argparse.ArgumentParser(
+    description='Generates a GeoJSON document from coverage areas of the Transport API Repository')
 parser.add_argument('--data', type=str, required=True, help='Path to the Transport API data')
 arguments = parser.parse_args()
 
@@ -31,7 +32,7 @@ for transportApiFile in transportApiFiles:
         name = os.path.splitext(os.path.basename(transportApiFile))[0]
 
     for cov in ['anyCoverage', 'regularCoverage', 'realtimeCoverage']:
-        if not 'coverage' in j or not cov in j['coverage'] or not 'area' in j['coverage'][cov]:
+        if 'coverage' not in j or cov not in j['coverage'] or 'area' not in j['coverage'][cov]:
             continue
         properties = {}
         properties['name'] = name + '-' + cov

--- a/tools/pretty-json.py
+++ b/tools/pretty-json.py
@@ -15,11 +15,11 @@ arguments = parser.parse_args()
 # read as JSON and normalize to standard formatting
 with open(arguments.filename, 'r') as f:
     j = json.loads(f.read())
-s = json.dumps(j, indent = 2)
+s = json.dumps(j, indent=2)
 
 # fold arrays of scalar values into one line
-s = re.sub(r'\[\n +(\"[A-Za-z-]+\"|[\d\.-]+)', r'[\1', s)
-s = re.sub(r',\n +(\"[A-Za-z-]+\"|[\d\.-]+)(?=[,\n])', r', \1', s)
+s = re.sub(r'\[\n +(\"[A-Za-z-]+\"|[\d.-]+)', r'[\1', s)
+s = re.sub(r',\n +(\"[A-Za-z-]+\"|[\d.-]+)(?=[,\n])', r', \1', s)
 s = re.sub(r'(?<![,\]}])\n +](\n|,\n)', r']\1', s)
 
 # output


### PR DESCRIPTION
I did fix some issues my python idea raised when looking at the files. Not everything is compliant with PEP8 rules yet, however imho. the most important things are fixed.
The rules I fixed are:
- PEP 8: E713 test for membership should be 'not in'
- PEP 8: E302 expected 2 blank lines, found 1
- PEP 8: E741 ambiguous variable name 'l'
- PEP 8: E231 missing whitespace after ','
- PEP 8: E251 unexpected spaces around keyword / parameter equals
- Redundant character escape '\.' in RegExp (Not PEP8)

You can read about the style guide here: https://pep8.org/

Feel free to comment, ask any questions or let me know if you do not want to include any of the changes.