### PR TITLE
DE: update BVG auth details

### DIFF
--- a/data/de/bvg-hafas-mgate.json
+++ b/data/de/bvg-hafas-mgate.json
@@ -27,16 +27,17 @@
   "options": {
     "endpoint": "https://bvg-apps-ext.hafas.de/bin/mgate.exe",
     "client": {
-      "type": "IPA",
-      "id": "BVG",
-      "name": "FahrInfo",
-      "v": "6020000"
+      "type": "WEB",
+      "id": "VBB",
+      "v": 10002,
+      "name": "webapp",
+      "l": "vs_webapp"
     },
     "ext": "BVG.1",
-    "ver": "1.24",
+    "ver": "1.72",
     "auth": {
       "type": "AID",
-      "aid": "YoJ05NartnanEGCj"
+      "aid": "dVg4TZbW8anjx9ztPwe2uk4LVRi9wO"
     },
     "products": [
       {


### PR DESCRIPTION
With the current config, the endpoint responds with `CLIENTVERSION: HCI Core: Invalid client version`.