### PR TITLE
KVB: Fix typo in bitmask for regional transit

### DIFF
--- a/data/de/kvb-hafas-mgate.json
+++ b/data/de/kvb-hafas-mgate.json
@@ -57,7 +57,7 @@
       },
       {
         "id": "regionalverkehr",
-        "bitmasks": [46],
+        "bitmasks": [16],
         "name": "Regionalverkehr"
       },
       {


### PR DESCRIPTION
I noticed that the KVB HAFAS bitmask for regional transit didn't look quite right when importing it into https://github.com/derf/Travel-Status-DE-DeutscheBahn. According to my tests, the bitmask should be 16 instead – 64 does not give any results.