### PR TITLE
NAH.SH mgate: Add type fields to request

### DIFF
--- a/data/de/nahsh-hafas-mgate.json
+++ b/data/de/nahsh-hafas-mgate.json
@@ -23,10 +23,12 @@
     "client": {
       "id": "NAHSH",
       "name": "NAHSHPROD",
+      "type": "IPH",
       "v": "3000700"
     },
     "ver": "1.16",
     "auth": {
+      "type": "AID",
       "aid": "r0Ot9FLFNAFxijLW"
     },
     "products": [


### PR DESCRIPTION
The NAH.SH mgate definition does not provide `type` fields in the `client` and `auth` parts of its `request`, causing the HAFAS backend to return error codes. Other mgate definitions provide these fields, so add them here as well.