### PR TITLE
ÖBB HAFAS: Add missing "type" field to request.auth

### DIFF
--- a/data/at/oebb-hafas-mgate.json
+++ b/data/at/oebb-hafas-mgate.json
@@ -1437,6 +1437,7 @@
     },
     "ver": "1.41",
     "auth": {
+      "type": "AID",
       "aid": "OWDL4fE4ixNiPBBm"
     },
     "products": [


### PR DESCRIPTION
Otherwise, HAFAS complains about "HCI Core: Parse fail : Parser error: root.auth(missing or incomplete: type)"

Similar to #87