### PR TITLE
resrobot: products: use "id", not "mode"

### DIFF
--- a/data/se/resrobot-hafas-mgate.json
+++ b/data/se/resrobot-hafas-mgate.json
@@ -56,11 +56,11 @@
             },
             {
                 "bitmasks": [ 256 ],
-                "mode": "ferry"
+                "id": "ferry"
             },
             {
                 "bitmasks": [ 512 ],
-                "mode": "on-demand"
+                "id": "on-demand"
             }
         ],
         "ver": "1.18"


### PR DESCRIPTION
Both according to schema / readme and according to all other entries in this repository, hafas products use "id" and not "mode"