### PR TITLE
BLS HAFAS: update endpoint

### DIFF
--- a/data/ch/bls-hafas-mgate.json
+++ b/data/ch/bls-hafas-mgate.json
@@ -29,7 +29,7 @@
       "name": "webapp",
       "l": "vs_webapp"
     },
-    "endpoint": "https://bls.hafas.de/bin/mgate.exe",
+    "endpoint": "https://bls.hafas.de/gate",
     "products": [
       {
         "id": "ice",


### PR DESCRIPTION
Two weeks ago, https://bls.hafas.de/bin/mgate.exe started returning HTTP 307 (temporary redirect) to https://bls.hafas.de/gate

I'm fairly sure that it is, in fact, permanent.