### PR TITLE
NASA HAFAS: Extend productbits

### DIFF
--- a/data/de/nasa-hafas-mgate.json
+++ b/data/de/nasa-hafas-mgate.json
@@ -45,6 +45,11 @@
         "name": "InterCity & EuroCity"
       },
       {
+        "id": "local",
+        "bitmasks": [4],
+        "name": "FlixTrain etc."
+      },
+      {
         "id": "regional",
         "bitmasks": [8],
         "name": "RegionalExpress & RegionalBahn"
@@ -61,8 +66,13 @@
       },
       {
         "id": "bus",
-        "bitmasks": [64, 128],
+        "bitmasks": [64],
         "name": "Bus"
+      },
+      {
+        "id": "on-demand",
+        "bitmasks": [128],
+        "name": "Rufbus"
       },
       {
         "id": "tourismTrain",


### PR DESCRIPTION
* Add local (e.g. FlixTrain)
* Split bus into bus (64) and on-demand (128)

I noticed this while working on travelynx and dbf.finalrewind.org, both of which use the backend list within this repository by now. You can observe both FlixTrain and bus vs on-demand departures at Halle(Saale)Hbf (EVA ID 90053), for instance.