### PR TITLE
DE: DB HAFAS: update ver & ext

### DIFF
--- a/data/de/db-hafas-mgate.json
+++ b/data/de/db-hafas-mgate.json
@@ -3167,7 +3167,7 @@
       "v": 19040000
     },
     "endpoint": "https://reiseauskunft.bahn.de/bin/mgate.exe",
-    "ext": "DB.R19.12.a",
+    "ext": "DB.R22.04.a",
     "locationIdentifierType": "db",
     "products": [
       {
@@ -3223,6 +3223,6 @@
     ],
     "standardLocationIdentifierCountries": [51, 53, 54, 55, 56, 70, 71, 74, 76, 80, 81, 82, 83, 84, 85, 86, 87, 88],
     "standardLocationIdentifierType": "ibnr",
-    "version": "1.18"
+    "version": "1.78"
   }
 }


### PR DESCRIPTION
The `ver` of `1.78` is reported by the server as the `hciVersion`.

remotely related discussions:
- https://matrix.to/#/!fGsJOaXhgnTCFCghEl:matrix.org/$Af-pOVmexMHJ9b5YYtV2ThMl5loSI0oY9YaPhdP3GNU?via=matrix.org&via=kde.org&via=tchncs.de
- https://github.com/public-transport/hafas-client/issues/331
- https://github.com/public-transport/hafas-client/issues/333
