### PR TITLE
Update Entur endpoint

### DIFF
--- a/data/no/entur-otp.json
+++ b/data/no/entur-otp.json
@@ -16,7 +16,7 @@
         }
     },
     "options": {
-        "endpoint": "https://api.entur.io/journey-planner/v2/graphql/",
+        "endpoint": "https://api.entur.io/journey-planner/v3/graphql/",
         "apiVersion": "entur"
     },
     "supportedLanguages": [ "no" ],


### PR DESCRIPTION
They also changed the OTP flavor needed to talk to this, but that's a detail we haven't modeled here. The old endpoint doesn't exist anymore, so this doesn't make things worse at least.