### PR TITLE
NAH.SH: Update endpoint URL

### DIFF
--- a/data/de/nahsh-hafas-mgate.json
+++ b/data/de/nahsh-hafas-mgate.json
@@ -19,7 +19,7 @@
     }
   },
   "options": {
-    "endpoint": "https://nah.sh.hafas.de/bin/mgate.exe",
+    "endpoint": "https://nahsh.hafas.cloud/gate",
     "client": {
       "id": "NAHSH",
       "name": "NAHSHPROD",


### PR DESCRIPTION
The old endpoint no longer works, instead returning a redirect.

```
> curl -I https://nah.sh.hafas.de/bin/mgate.exe
HTTP/1.1 307 Temporary Redirect        
Date: Sat, 06 Sep 2025 18:21:48 GMT
Content-Type: text/html
Content-Length: 164
Connection: keep-alive
Location: https://nahsh.hafas.cloud/gate
```

In my experience, those redirects are never temporary, despite the HTTP status indicating otherwise.