### PR TITLE
Add `stopTimes` field to MOTIS

### DIFF
--- a/data/de/rnv-motis.json
+++ b/data/de/rnv-motis.json
@@ -11,7 +11,8 @@
   "options": {
     "endpoint": "https://directions.nwex.de/api/providers/rhein-neckar-verkehr/",
     "intermodal": false,
-    "motisVersion": "2.0.43",
+    "motisVersion": "2.7.6",
+    "stopTimes": {},
     "supportedModes": []
   },
   "supportedLanguages": [

--- a/data/un/transitous.json
+++ b/data/un/transitous.json
@@ -9134,7 +9134,11 @@
   "options": {
     "endpoint": "https://api.transitous.org/",
     "intermodal": false,
-    "motisVersion": "2.0.17",
+    "motisVersion": "2.7.6",
+    "stopTimes": {
+        "radius": 200,
+        "exactRadius": false
+    },
     "supportedModes": []
   },
   "supportedLanguages": [],

--- a/readme.md
+++ b/readme.md
@@ -291,6 +291,7 @@ The following properties are defined:
 * `motisVersion`: version of the [motis-server](https://github.com/motis-project/motis/releases)
 * `supportedModes`: A list of [individual transport modes](https://motis-project.de/docs/api/endpoint/intermodal.html#modes) supported
 in intermodal routing requests (e.g. `FootPPR`, `Bike`, `Car`, `CarParking`).
+* `stopTimes`: Additional parameters expected by clients to be set on the `stoptimes` API endpoint.
 
 ## Contributing
 


### PR DESCRIPTION
This pull request adds a new `stopTimes` field to the options for MOTIS apis. This field can specify a set of parameters to be set as part of the request when using the `stoptimes` api.

Currently the option includes `radius=200` for Transitous and no values for RNV MOTIS.

While the MOTIS web interface defaults to a radius of 200 meters, setting this for all MOTIS endpoints unconditionally causes wrong departures to be listed for deployments with well maintained parent stations, such as the RNV MOTIS.

See https://github.com/derf/travelynx/issues/341