### PR TITLE
oebb: Switch to settings used by the web interface

### DIFF
--- a/data/at/oebb-hafas-mgate.json
+++ b/data/at/oebb-hafas-mgate.json
@@ -1694,17 +1694,18 @@
     }
   },
   "options": {
-    "endpoint": "https://fahrplan.oebb.at/bin/mgate.exe",
+    "endpoint": "https://fahrplan.oebb.at/gate",
     "client": {
-      "type": "IPH",
       "id": "OEBB",
-      "v": "6030600",
-      "name": "oebbPROD-ADHOC"
+      "type": "WEB",
+      "name": "webapp",
+      "l": "vs_webapp",
+      "v": 21804
     },
-    "ver": "1.45",
+    "ver": "1.88",
     "auth": {
       "type": "AID",
-      "aid": "OWDL4fE4ixNiPBBm"
+      "aid": "5vHavmuWPWIfetEe"
     },
     "products": [
       {


### PR DESCRIPTION
These should be easier to keep up to date (only browser devtools required).
web interface: https://fahrplan.oebb.at/webapp