### PR TITLE
Update versions of the deployed MOTIS APIs

### DIFF
--- a/data/de/europe-motis.json
+++ b/data/de/europe-motis.json
@@ -1,5 +1,5 @@
 {
-  "name": "Demo Instance of MOTIS Project for a part of europe",
+  "name": "Demo Instance of MOTIS Project for a part of Europe",
   "coverage": {
     "regularCoverage": {
       "region": [
@@ -1971,7 +1971,7 @@
   },
   "options": {
     "endpoint": "https://europe.motis-project.de/",
-    "motisVersion": "0.10.0",
+    "motisVersion": "2.10.2",
     "supportedModes": [ "FootPPR", "Bike", "Car", "CarParking" ]
   },
   "supportedLanguages": [

--- a/data/de/rnv-motis.json
+++ b/data/de/rnv-motis.json
@@ -11,7 +11,7 @@
   "options": {
     "endpoint": "https://directions.nwex.de/api/providers/rhein-neckar-verkehr/",
     "intermodal": false,
-    "motisVersion": "2.0.43",
+    "motisVersion": "2.10.0",
     "supportedModes": []
   },
   "supportedLanguages": [

--- a/data/un/transitous.json
+++ b/data/un/transitous.json
@@ -10005,7 +10005,7 @@
   "options": {
     "endpoint": "https://api.transitous.org/",
     "intermodal": false,
-    "motisVersion": "2.0.17",
+    "motisVersion": "2.10.2",
     "supportedModes": []
   },
   "supportedLanguages": [],


### PR DESCRIPTION
There are no 0.x deployments tracked in this repo anymore, as all known endpoints have at least version 2.10.0